### PR TITLE
Quiet hoyolab-auto to info, and pick up the code-source warnings

### DIFF
--- a/services/hoyolab-auto/Dockerfile
+++ b/services/hoyolab-auto/Dockerfile
@@ -1,4 +1,10 @@
-FROM ghcr.io/janejeon/hoyolab-auto:sha-be75753
+# --platform is required, not cosmetic. The upstream image is published amd64
+# only (JaneJeon/hoyolab-auto .github/workflows/docker-image.yaml), because
+# Railway runs x86-64 and the emulated arm64 leg was half the build's wall clock
+# and where a build once hung. Without this line, `docker build` on an Apple
+# Silicon Mac fails with "no match for platform in manifest", which breaks the
+# pre-push hook and golden rule 2 for everyone on arm64 hardware.
+FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-c2f73e8
 
 # Image runs as non-root 'hoyolab'; stay as root to install packages and run entrypoint
 USER root

--- a/services/hoyolab-auto/config.json5.envsubst
+++ b/services/hoyolab-auto/config.json5.envsubst
@@ -1,5 +1,14 @@
 {
-    loglevel: 'debug',
+    // 'info', not 'debug'. Debug logs every HTTP request, including the 5-second
+    // Telegram poll, which is ~17k lines a day. That volume exhausted Railway's
+    // log retention during the 2026-08-28 investigation: the forensic trail
+    // could not reach back 36 hours. Railway logs are the only history there is,
+    // since nothing ships them anywhere (NETWORKING.md: Railway containers
+    // cannot reach the Home Assistant VictoriaLogs stack), so burning retention
+    // costs real evidence.
+    //
+    // Raise to 'debug' deliberately while investigating, then put it back.
+    loglevel: 'info',
     userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0',
     retry: {
         attempts: 2,


### PR DESCRIPTION
First PR to this repo rather than a direct push to master. Part of [JANE-236](https://linear.app/janejeon/issue/JANE-236/hoyolab-auto-alert-on-real-failures-not-just-on-a-synthetic-probe).

## Three changes

**`loglevel: 'debug'` to `'info'`.** Debug logs every HTTP request, including the 5-second Telegram poll, which is roughly 17k lines a day. That volume exhausted Railway's log retention during the 2026-08-28 investigation: the forensic trail could not reach back 36 hours. Railway logs are the only history there is, since `NETWORKING.md` records that Railway containers cannot reach the Home Assistant VictoriaLogs stack, so burning retention costs real evidence.

**Image pin to `sha-c2f73e8`.** Carries the health cron blind-spot fixes ([#7](https://github.com/JaneJeon/hoyolab-auto/pull/7)), the removal of the cookie-refresh cron ([#9](https://github.com/JaneJeon/hoyolab-auto/pull/9)), and code-source failure reporting ([#10](https://github.com/JaneJeon/hoyolab-auto/pull/10)).

**`FROM --platform=linux/amd64`.** Required, not cosmetic. See below.

## Ordering matters, and it is the reason these ship together

Dropping to `info` deletes the `debug` line that was the *only* trace of a dead code source. The pinned image raises that failure to `warn` instead. Doing these in the other order would have opened a window where a dead `api.ennead.cc` produced no signal at all.

## The platform pin, found by the pre-push hook

The first push attempt failed the Docker build with `no match for platform in manifest`. That is a regression from [#6](https://github.com/JaneJeon/hoyolab-auto/pull/6), which dropped arm64 from the image build. Railway runs x86-64 so production was never affected, but every local build on Apple Silicon now fails, which breaks golden rule 2 for this service.

Pinning the platform explicitly fixes it and is more correct anyway, since the deployed platform should not depend on who runs the build. Docker warns against a constant `--platform`; that advice does not apply when the base image exists for exactly one architecture.

## Verified

- `docker build` of this service: passes, and the pre-push hook now passes.
- The pinned image was built and started against a scratch config before the pin was written: `Initialized 13 cron jobs`, no crash.
- `gitleaks`: no leaks found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)