### PR TITLE
Correct the cookie-rotation runbook after the refresh cron was deleted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,8 +305,11 @@ instrument fault reads as one missed heartbeat rather than as a dead credential.
 a reason, or when a probe you ran by hand returns a non-zero retcode. A DOWN
 with no reason means the probe could not decide (timeout, DNS) and the
 credential may be fine — check the monitor's last message before rotating
-anything. There is no automatic path: the bot's `crons/update-cookie` calls an
-endpoint HoYoverse retired, so it can never succeed.
+anything. There is no automatic path and there cannot be one. Upstream's
+`crons/update-cookie` was deleted from the fork on 2026-09-01: it called an
+endpoint HoYoverse retired, it wrote v1 field names redemption does not read,
+and it only mutated memory that the next restart discarded. Rotation is manual,
+always.
 
 1. Capture a fresh cookie from a logged-in `act.hoyolab.com` page. **Never from
    `hsr.hoyoverse.com/gift`** — that page sets only three of the six required


### PR DESCRIPTION
Docs only. Part of [JANE-236](https://linear.app/janejeon/issue/JANE-236/hoyolab-auto-alert-on-real-failures-not-just-on-a-synthetic-probe).

The rotation runbook said there is no automatic path because `crons/update-cookie` calls a retired endpoint. That was true of a cron that still existed. It was deleted from the fork in [JaneJeon/hoyolab-auto#9](https://github.com/JaneJeon/hoyolab-auto/pull/9), so the sentence now points at a file that is gone.

Records *why* it was removed rather than only that it was. This is a semi-fork ([JANE-237](https://linear.app/janejeon/issue/JANE-237/hoyolab-auto-is-a-semi-fork-with-no-path-to-take-upstream-fixes)) and upstream still ships that cron, so a future port would restore all three faults: a retired endpoint, v1 field names redemption does not read, and a write that only touches memory the next restart discards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)