### PR TITLE
Deploy redemption retcode logging

### DIFF
--- a/services/hoyolab-auto/Dockerfile
+++ b/services/hoyolab-auto/Dockerfile
@@ -4,7 +4,7 @@
 # and where a build once hung. Without this line, `docker build` on an Apple
 # Silicon Mac fails with "no match for platform in manifest", which breaks the
 # pre-push hook and golden rule 2 for everyone on arm64 hardware.
-FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-c2f73e8
+FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-3ce14e0
 
 # Image runs as non-root 'hoyolab'; stay as root to install packages and run entrypoint
 USER root


### PR DESCRIPTION
Pins `sha-3ce14e0`, which carries [JaneJeon/hoyolab-auto#11](https://github.com/JaneJeon/hoyolab-auto/pull/11).

`redeemCodes` now logs and returns the vendor retcode instead of reading it, branching on it, and throwing it away.

Nothing classifies on it yet, deliberately. The point is that the inventory of what `webExchangeCdkey` actually returns starts accumulating from real traffic. That inventory is the single thing [JANE-236](https://linear.app/janejeon/issue/JANE-236/hoyolab-auto-alert-on-real-failures-not-just-on-a-synthetic-probe) outcome monitoring is blocked on: without it there is no way to decide whether an unrecognised retcode should read as healthy or broken, and both wrong answers are bad. Treating unknown as broken pages on routine region-ineligibility; treating it as healthy is how a real outage stays green.

The pre-push Docker build passed, and gitleaks found no leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)