### PR TITLE
Deploy separated HoYoLab notifications and durable daily reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,19 +346,22 @@ deployment and the monitor rationale.
 
 ### Who is allowed to alert
 
-One rule decides most design questions here. **A service must never alert.** It
-emits logs, and it pushes heartbeats. That is all.
+For operational mechanism health, **a service must never page directly**. It
+emits logs and pushes outcome heartbeats; Kuma and PagerDuty own health paging.
+Domain Action pings (for example unfinished game chores) are a separate policy:
+Rethink Notifications, JANE-241–244, routes those through Telegram Alerts.
 
-| Layer       | Job                                                       |
-| ----------- | --------------------------------------------------------- |
-| The service | Do the work, log it, push a heartbeat carrying an outcome |
-| Uptime Kuma | Decide up, down or silence, and hold the history          |
-| PagerDuty   | Urgency, escalation, quiet hours, deferral                |
-| Telegram    | A log Jane can silence and read back later, not a channel |
+| Layer       | Job                                                              |
+| ----------- | ---------------------------------------------------------------- |
+| The service | Do the work, log it, push a heartbeat carrying an outcome        |
+| Uptime Kuma | Decide up, down or silence, and hold the history                 |
+| PagerDuty   | Urgency, escalation, quiet hours, deferral                       |
+| Telegram    | Domain Action pings and silent Receipt history; no health paging |
 
-Telegram is **not** an alert path, and neither is a second "alerts" bot. Jane is
-phasing that channel out. An earlier plan to route failures there is recorded as
-superseded on JANE-233; do not rebuild it.
+Telegram is **not** an operational health alert path. The earlier plan to route
+mechanism failures to a second bot remains superseded on JANE-233. The Alerts
+bot now carries domain Action pings; automation Receipts, including failures,
+go silently to the Notifications bot. Neither replaces Kuma/PagerDuty.
 
 ### Quiet hours are a PagerDuty setting, not a service setting
 

--- a/services/hoyolab-auto/Dockerfile
+++ b/services/hoyolab-auto/Dockerfile
@@ -4,7 +4,7 @@
 # and where a build once hung. Without this line, `docker build` on an Apple
 # Silicon Mac fails with "no match for platform in manifest", which breaks the
 # pre-push hook and golden rule 2 for everyone on arm64 hardware.
-FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-3ce14e0
+FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-d5881ef
 
 # Image runs as non-root 'hoyolab'; stay as root to install packages and run entrypoint
 USER root
@@ -16,5 +16,5 @@ COPY --chown=hoyolab:hoyolab config.json5.envsubst /app/config.json5.template
 # Fix volume mount ownership (volume dirs are created as root), render config,
 # then drop to unprivileged user to run the app
 CMD ["sh", "-c", "chown hoyolab:hoyolab /app/data && \
-    envsubst '$TELEGRAM_CHAT_ID $TELEGRAM_NOTIFICATIONS_BOT_TOKEN $HOYOLAB_COOKIE $KUMA_PUSH_URL_LIVENESS $KUMA_PUSH_URL_LTOKEN $KUMA_PUSH_URL_COOKIE_TOKEN' < /app/config.json5.template > /app/config.json5 && \
+    envsubst '$TELEGRAM_CHAT_ID $TELEGRAM_NOTIFICATIONS_BOT_TOKEN $TELEGRAM_ALERTS_CHAT_ID $TELEGRAM_ALERTS_BOT_TOKEN $HOYOLAB_COOKIE $KUMA_PUSH_URL_LIVENESS $KUMA_PUSH_URL_LTOKEN $KUMA_PUSH_URL_COOKIE_TOKEN' < /app/config.json5.template > /app/config.json5 && \
     exec su-exec hoyolab npm start"]

--- a/services/hoyolab-auto/README.md
+++ b/services/hoyolab-auto/README.md
@@ -9,3 +9,26 @@ NOTE: all of the uptime kuma URLs are in forms of `http://${{"Uptime Kuma".RAILW
 DO NOT MANUALLY SET THE DOMAIN, DO NOT WILLY NILLY OVERWRITE THE URLs!
 
 Also you CANNOT have the `https://` prefix if using the Railway private domains like this!
+
+## Notification routing and reminders
+
+`TELEGRAM_NOTIFICATIONS_BOT_TOKEN` / `TELEGRAM_CHAT_ID` receive Receipt messages
+silently. `TELEGRAM_ALERTS_BOT_TOKEN` / `TELEGRAM_ALERTS_CHAT_ID` receive Action
+pings. Tokens are maintained in 1Password and injected through Railway stdin;
+all four variable names must remain in the Dockerfile's runtime envsubst list.
+Commands, including `/tasks`, reply only in their originating bot/chat.
+
+The deadline coordinator checks live notes every two minutes and at startup.
+Daily reminders use T-20/12/7/4/2 hours relative to each account's 04:00 game
+server reset. The state and delivered-rung ledger persist at
+`/app/data/reminders.json` on the existing volume. Completion cancels later
+rungs; missing or stale evidence is unknown. Display zones never silence pings.
+
+Weekly offsets are intentionally not configured yet: the three-hour estimate
+needs clarification (combined workload or per game). The legacy weekly cron
+continues until that policy is settled. The current task view already includes
+fresh weekly progress. Do not mark the weekly acceptance work complete.
+
+The three Kuma monitors retain their existing private HTTP references. They
+cover process and credential health, not fresh-notes or delivery correctness;
+that coverage remains a separate monitoring task.

--- a/services/hoyolab-auto/config.json5.envsubst
+++ b/services/hoyolab-auto/config.json5.envsubst
@@ -29,6 +29,13 @@
             cookieToken: '$KUMA_PUSH_URL_COOKIE_TOKEN',
         },
     },
+    reminders: {
+        enabled: true,
+        dailyOffsets: [20, 12, 7, 4, 2],
+        // Weekly offsets await clarification of the three-hour workload estimate.
+        // Until configured, the existing weekly reminder remains registered.
+        displayTimezones: ['America/Los_Angeles', 'America/New_York', 'Asia/Seoul'],
+    },
     platforms: [
         {
             id: 1,
@@ -43,7 +50,17 @@
             type: 'telegram',
             chatId: $TELEGRAM_CHAT_ID, // You can follow this guide to create a bot: https://github.com/torikushiii/hoyolab-auto/blob/main/setup/TELEGRAM.md
             token: '$TELEGRAM_NOTIFICATIONS_BOT_TOKEN',
-            disableNotification: false, // Set to true if you want to disable notification for Telegram bot (sounds, vibration, etc.)
+            notificationClasses: ['Receipt'],
+            disableNotification: true, // Set to true if you want to disable notification for Telegram bot (sounds, vibration, etc.)
+        },
+        {
+            id: 4,
+            active: true,
+            type: 'telegram',
+            chatId: $TELEGRAM_ALERTS_CHAT_ID,
+            token: '$TELEGRAM_ALERTS_BOT_TOKEN',
+            notificationClasses: ['Action'],
+            disableNotification: false,
         },
         {
             id: 3,
@@ -64,7 +81,7 @@
         missedCheckIn: '0 23 * * *',
         realmCurrency: '0 */1 * * *',
         shopStatus: '0 */1 * * *',
-        stamina: '*/2 * * * *',
+        deadlineReminders: '*/2 * * * *',
     },
     accounts: [
         {


### PR DESCRIPTION
Deploy the notification contract and durable daily reminders from JaneJeon/hoyolab-auto PRs #13 and #14, pinning published image `sha-d5881ef`.

The Notifications bot receives silent Receipts; the Alerts bot receives Action pings. Both new Alerts variables are included in runtime envsubst and were configured with `--skip-deploys`. Daily reminders now use fresh observations and the persisted server-period ledger; `/tasks` displays current outstanding chores and freshness. The existing weekly cron remains active because the new weekly ladder awaits workload clarification.

The three Kuma variable references and existing `/app/data` volume are preserved. Documentation distinguishes domain pings from operational health paging.

Validation: independent Sol configuration review; actual amd64 deployment Docker build; runtime entrypoint smoke test with dummy variables asserts both message classes, silence flags, chat IDs, active account types, and complete envsubst, then safely boots with accounts disabled. Application suite: 78 tests passed. Live routing and state checks follow Railway deployment; the daily/weekly acceptance period remains open.
