### PR TITLE
Deploy current weekly progress and task-view fixes

### DIFF
--- a/services/hoyolab-auto/Dockerfile
+++ b/services/hoyolab-auto/Dockerfile
@@ -4,7 +4,7 @@
 # and where a build once hung. Without this line, `docker build` on an Apple
 # Silicon Mac fails with "no match for platform in manifest", which breaks the
 # pre-push hook and golden rule 2 for everyone on arm64 hardware.
-FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-d5881ef
+FROM --platform=linux/amd64 ghcr.io/janejeon/hoyolab-auto:sha-33b0cf1
 
 # Image runs as non-root 'hoyolab'; stay as root to install packages and run entrypoint
 USER root

--- a/services/hoyolab-auto/README.md
+++ b/services/hoyolab-auto/README.md
@@ -32,3 +32,13 @@ fresh weekly progress. Do not mark the weekly acceptance work complete.
 The three Kuma monitors retain their existing private HTTP references. They
 cover process and credential health, not fresh-notes or delivery correctness;
 that coverage remains a separate monitoring task.
+
+### Current weekly objects
+
+The task view and legacy weekly emitter use the current game mechanics:
+Star Rail tracks Echo of War plus the unified Cyclical Points track; Zenless
+tracks Lost Void Bounty plus Ridu Weekly. Legacy mode counters and the retired
+Investigation Points weekly limit do not create extra obligations. Missing
+progress for an actual obligation remains unknown. See
+[application PR #15](https://github.com/JaneJeon/hoyolab-auto/pull/15) for the
+live-response evidence, official update references, and regression coverage.


### PR DESCRIPTION
Deploy [hoyolab-auto PR #15](https://github.com/JaneJeon/hoyolab-auto/pull/15) by pinning the published `sha-33b0cf1` image.

The live task view and existing weekly emitter now follow the current game obligations: Echo of War plus unified Cyclical Points for Star Rail, and Lost Void Bounty plus Ridu Weekly for Zenless. Retired or mirrored API fields no longer create phantom tasks. Missing evidence remains unknown, and catch-up reminders report the actual time remaining.

No routing, credential, volume, Kuma-reference, or weekly-schedule changes. The expanded weekly ladder is still pending workload clarification.

Validation: application suite 84/84, independent Sol review, Docker deployment build and runtime entrypoint test with scratch values. Post-deploy verification will check the corrected live projection and existing reminder ledger across restart.
